### PR TITLE
updates to make writing spf tests easier 

### DIFF
--- a/library/pipeline/fhir_calls/fhir_mock/v1/pipeline.py
+++ b/library/pipeline/fhir_calls/fhir_mock/v1/pipeline.py
@@ -31,7 +31,6 @@ class FhirCalls(FrameworkPipeline):
                     print(">>>", response.text)
             elif isinstance(content, dict):
                 resource_name = content.get("resourceType")
-                # content["meta"]["source"] = "foo"
                 url = f"{mock_server_url}/{test_name}/4_0_0/{resource_name}/1/$merge"
                 response = requests.post(f"{url}", json=[content])
                 assert response.ok

--- a/library/pipeline/fhir_calls/fhir_mock/v1/pipeline.py
+++ b/library/pipeline/fhir_calls/fhir_mock/v1/pipeline.py
@@ -31,6 +31,7 @@ class FhirCalls(FrameworkPipeline):
                     print(">>>", response.text)
             elif isinstance(content, dict):
                 resource_name = content.get("resourceType")
+                # content["meta"]["source"] = "foo"
                 url = f"{mock_server_url}/{test_name}/4_0_0/{resource_name}/1/$merge"
                 response = requests.post(f"{url}", json=[content])
                 assert response.ok

--- a/spark_pipeline_framework_testing/test_classes/validator_types.py
+++ b/spark_pipeline_framework_testing/test_classes/validator_types.py
@@ -558,12 +558,12 @@ class MockRequestValidator(Validator):
 
 class OutputFileValidator(Validator):
     """
-    compare input and output files
+    Validates the output files from a feature or pipeline
     """
 
     def __init__(
         self,
-        related_inputs: Union[List["FileInput"], "FileInput"],
+        related_inputs: Optional[Union[List["FileInput"], "FileInput"]] = None,
         func_path_modifier: Optional[
             Callable[[Union[Path, str]], Union[Path, str]]
         ] = convert_path_from_docker,
@@ -579,7 +579,8 @@ class OutputFileValidator(Validator):
     ):
         """
 
-        :param related_inputs: the corresponding input for this validator
+        :param related_inputs: the corresponding input for this validator, optional if the pipeline input comes
+            from calling an api
         :param func_path_modifier: in case you want to change paths e.g. docker to local
         :param sort_output_by: order of column names [col1, col2,...]
         :param output_as_json_only: save output as json
@@ -619,11 +620,11 @@ class OutputFileValidator(Validator):
         mock_client: Optional[MockServerFriendlyClient] = None,
     ) -> None:
         assert spark_session
-        assert self.related_inputs
-        assert self.related_inputs[0].input_table_names  # type: ignore
         self.logger = logger
 
-        self.input_table_names = self.related_inputs[0].input_table_names  # type: ignore
+        self.input_table_names = []
+        if self.related_inputs:
+            self.input_table_names = self.related_inputs[0].input_table_names  # type: ignore
         self.spark_session = spark_session
         self.test_path = test_path
         self.output_folder_path = test_path.joinpath(self.output_folder)

--- a/tests/library/features/v2/fhir_calls/fhir_mock/request_no_expectation/1111111111-RRR-GGGG.json
+++ b/tests/library/features/v2/fhir_calls/fhir_mock/request_no_expectation/1111111111-RRR-GGGG.json
@@ -1,0 +1,45 @@
+{
+  "resourceType": "Practitioner",
+  "id": "1111111111-RRR-GGGG",
+  "meta": {
+    "source": "http://medstarhealth.org/provider_appointment_type",
+    "security": [
+      {
+        "system": "https://www.icanbwell.com/access",
+        "code": "medstar"
+      },
+      {
+        "system": "https://www.icanbwell.com/owner",
+        "code": "medstar"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "http://medstarhealth.org",
+      "value": "1629334859-TT3-GPPC"
+    }
+  ],
+  "type": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/service-category",
+          "display": "PrimaryCare"
+        },
+        {
+          "system": "http://medstarhealth.org/protocol",
+          "code": "PrimaryCare",
+          "display": "PrimaryCare"
+        }
+      ]
+    }
+  ],
+  "location": [
+    {
+      "reference": "Location/Medstar-Alias-TT3-GPPC"
+    }
+  ],
+  "name": "PrimaryCare"
+}

--- a/tests/library/features/v2/fhir_calls/fhir_mock/test_fhir_mock.py
+++ b/tests/library/features/v2/fhir_calls/fhir_mock/test_fhir_mock.py
@@ -56,3 +56,53 @@ def test_fhir_mock(spark_session: SparkSession) -> None:
         temp_folder="temp",
         helix_pipeline_parameters=params,
     ).run_test2()
+
+
+def test_mock_request_validator_no_mock_requests_folder(
+    spark_session: SparkSession,
+) -> None:
+    """
+    if using the FhirCalls input verify that the MockRequestValidator works correctly when no mock_requests_folder
+    is provided. The purpose of providing the mock_requests_folder is so that FHIR resources created by the pipeline
+    or code under test that do not have an expectation are written to a folder that has the same name as the resource
+    """
+    test_path: Path = Path(__file__).parent.joinpath("./")
+    test_name = "test_fhir_mock"
+
+    mock_server_url = "http://mock-server:1080"
+    mock_client = MockServerFriendlyClient(mock_server_url)
+    mock_client.reset()
+    mock_client.clear(f"/{test_name}/")
+
+    fhir_calls = FhirCalls()
+    test_validators = MockRequestValidator()
+
+    params = {
+        "test_name": test_name,
+        "mock_server_url": mock_server_url,
+        "files_path": [
+            test_path.joinpath(
+                "fhir_calls/healthcare_service/1629334859-TT3-GPPC.json"
+            ),
+            test_path.joinpath(
+                "fhir_calls/healthcare_service/1790914448-TT4-GPPC.json"
+            ),
+            test_path.joinpath("fhir_calls/location/Medstar-Alias-TT3-GPPC.json"),
+            test_path.joinpath("fhir_calls/location/Medstar-Alias-TT4-GPPC.json"),
+            test_path.joinpath("request_no_expectation/1111111111-RRR-GGGG.json"),
+        ],
+    }
+    logger = get_logger(__name__)
+    SparkPipelineFrameworkTestRunnerV2(
+        spark_session=spark_session,
+        test_path=test_path,
+        test_name=test_name,
+        test_validators=[test_validators],
+        logger=logger,
+        auto_find_helix_transformer=False,
+        helix_transformers=[PipelineFhirCallsFhirMockV1],
+        mock_client=mock_client,
+        test_inputs=[fhir_calls],
+        temp_folder="temp",
+        helix_pipeline_parameters=params,
+    ).run_test2()

--- a/tests/library/features/v2/fhir_calls/fhir_mock/test_fhir_mock.py
+++ b/tests/library/features/v2/fhir_calls/fhir_mock/test_fhir_mock.py
@@ -9,7 +9,7 @@ from library.pipeline.fhir_calls.fhir_mock.v1.pipeline_fhir_calls_fhir_mock_v1 i
 )
 from spark_pipeline_framework_testing.test_classes.input_types import FhirCalls
 from spark_pipeline_framework_testing.test_classes.validator_types import (
-    MockCallValidator,
+    MockRequestValidator,
 )
 from spark_pipeline_framework_testing.test_runner_v2 import (
     SparkPipelineFrameworkTestRunnerV2,
@@ -26,7 +26,8 @@ def test_fhir_mock(spark_session: SparkSession) -> None:
     mock_client.clear(f"/{test_name}/")
 
     fhir_calls = FhirCalls()
-    test_validators = MockCallValidator(related_inputs=fhir_calls)
+    test_validators = MockRequestValidator(mock_requests_folder="fhir_calls")
+
     params = {
         "test_name": test_name,
         "mock_server_url": mock_server_url,

--- a/tests/library/features/v2/mock_fhir_request/test_mock_fhir_request.py
+++ b/tests/library/features/v2/mock_fhir_request/test_mock_fhir_request.py
@@ -41,7 +41,9 @@ def test_mock_fhir_request_with_validation(spark_session: SparkSession) -> None:
     )
 
 
-def test_mock_request_validator_without_mock_requests_folder(spark_session: SparkSession) -> None:
+def test_mock_request_validator_without_mock_requests_folder(
+    spark_session: SparkSession,
+) -> None:
     test_path: Path = Path(__file__).parent.joinpath("./")
     test_name = "test_mock_fhir_request"
 
@@ -59,7 +61,7 @@ def test_mock_request_validator_without_mock_requests_folder(spark_session: Spar
     )
     requests.get(
         f"{mock_server_url}/{test_name}/4_0_0/InsurancePlan/fhir_insurance_plan_resource"
-    )   
+    )
     mock_call_validator = MockRequestValidator()
     mock_call_validator.validate(
         test_name=test_name,

--- a/tests/library/features/v2/mock_fhir_request/test_mock_fhir_request.py
+++ b/tests/library/features/v2/mock_fhir_request/test_mock_fhir_request.py
@@ -7,11 +7,11 @@ from pyspark.sql import SparkSession
 
 from spark_pipeline_framework_testing.test_classes import input_types
 from spark_pipeline_framework_testing.test_classes.validator_types import (
-    MockCallValidator,
+    MockRequestValidator,
 )
 
 
-def test_source_api_call(spark_session: SparkSession) -> None:
+def test_mock_fhir_request_with_validation(spark_session: SparkSession) -> None:
     test_path: Path = Path(__file__).parent.joinpath("./")
     test_name = "test_mock_fhir_request"
 
@@ -30,7 +30,37 @@ def test_source_api_call(spark_session: SparkSession) -> None:
     requests.get(
         f"{mock_server_url}/{test_name}/4_0_0/InsurancePlan/fhir_insurance_plan_resource"
     )
-    mock_call_validator = MockCallValidator(related_inputs=mock_fhir_request)
+    mock_call_validator = MockRequestValidator(mock_requests_folder="mock_requests")
+    mock_call_validator.validate(
+        test_name=test_name,
+        test_path=test_path,
+        spark_session=spark_session,
+        temp_folder_path=test_path.joinpath("temp"),
+        logger=logger,
+        mock_client=mock_client,
+    )
+
+
+def test_mock_request_validator_without_mock_requests_folder(spark_session: SparkSession) -> None:
+    test_path: Path = Path(__file__).parent.joinpath("./")
+    test_name = "test_mock_fhir_request"
+
+    mock_server_url = "http://mock-server:1080"
+    mock_client = MockServerFriendlyClient(mock_server_url)
+    mock_client.clear(path=f"/{test_name}/*.*")
+
+    logger = logging.getLogger(__name__)
+
+    mock_fhir_request = input_types.MockFhirRequest(
+        fhir_calls_folder="mock_requests", fhir_resource_type="InsurancePlan"
+    )
+    mock_fhir_request.initialize(
+        test_name=test_name, test_path=test_path, mock_client=mock_client, logger=logger
+    )
+    requests.get(
+        f"{mock_server_url}/{test_name}/4_0_0/InsurancePlan/fhir_insurance_plan_resource"
+    )   
+    mock_call_validator = MockRequestValidator()
     mock_call_validator.validate(
         test_name=test_name,
         test_path=test_path,


### PR DESCRIPTION
created MockRequestValidator to simplify validating different types of requests.
- remove the tight coupling with the FhirCalls input type
- improve the parameter names to make them more meaningful
- added some comments around how MockServerRequestNotFoundException exceptions are handled 

updated OutputFileValidator so that `related_inputs` is not longer needed. previously the validator would only function if there was an input directory in the test folder. some of new style pipelines get their data from api calls and output non fhir flat files so removing the dependency on input files removes the need to have an input folder with a dummy file in it.   
