### PR TITLE
attempting to fix OutputFileValidator so that whatever views are specified via ignore_views_for_output are not used to generate the output files and schema and are not used for comparison

### DIFF
--- a/spark_pipeline_framework_testing/test_classes/validator_types.py
+++ b/spark_pipeline_framework_testing/test_classes/validator_types.py
@@ -735,8 +735,8 @@ class OutputFileValidator(Validator):
         output_files: List[str] = [
             f
             for f in listdir(self.output_folder_path)
-            if isfile(join(self.output_folder_path, f)) # and file without extension is not in ignore_views_for_output
-            and f.split(".")[0] not in self.ignore_views_for_output
+            if isfile(join(self.output_folder_path, f))
+            and Path(f).stem not in self.ignore_views_for_output
         ]
         views_found: List[str] = []
         data_frame_exceptions: List[SparkDataFrameComparerException] = []

--- a/spark_pipeline_framework_testing/test_classes/validator_types.py
+++ b/spark_pipeline_framework_testing/test_classes/validator_types.py
@@ -735,7 +735,8 @@ class OutputFileValidator(Validator):
         output_files: List[str] = [
             f
             for f in listdir(self.output_folder_path)
-            if isfile(join(self.output_folder_path, f))
+            if isfile(join(self.output_folder_path, f)) # and file without extension is not in ignore_views_for_output
+            and f.split(".")[0] not in self.ignore_views_for_output
         ]
         views_found: List[str] = []
         data_frame_exceptions: List[SparkDataFrameComparerException] = []
@@ -764,6 +765,7 @@ class OutputFileValidator(Validator):
             if table_name.lower() not in views_found
             and not table_name.startswith("expected_")
             and table_name not in self.input_table_names
+            and table_name not in self.ignore_views_for_output
         ]
         if (
             "output" in table_names_to_write_to_output

--- a/tests/library/pipeline/fixed_width_pipeline/v1/output/books.json
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/output/books.json
@@ -1,0 +1,110 @@
+[
+  {
+    "_id": "bk101",
+    "author": "Gambardella, Matthew",
+    "description": "\n\n\n         An in-depth look at creating applications\n         with XML.This manual describes Oracle XML DB, and how you can use it to store, generate, manipulate, manage,\n         and query XML data in the database.\n\n\n         After introducing you to the heart of Oracle XML DB, namely the XMLType framework and Oracle XML DB repository,\n         the manual provides a brief introduction to design criteria to consider when planning your Oracle XML DB\n         application. It provides examples of how and where you can use Oracle XML DB.\n\n\n         The manual then describes ways you can store and retrieve XML data using Oracle XML DB, APIs for manipulating\n         XMLType data, and ways you can view, generate, transform, and search on existing XML data. The remainder of\n         the manual discusses how to use Oracle XML DB repository, including versioning and security,\n         how to access and manipulate repository resources using protocols, SQL, PL/SQL, or Java, and how to manage\n         your Oracle XML DB application using Oracle Enterprise Manager. It also introduces you to XML messaging and\n         Oracle Streams Advanced Queuing XMLType support.\n      ",
+    "genre": "Computer",
+    "price": 44.95,
+    "publish_date": "2000-10-01",
+    "title": "XML Developer's Guide"
+  },
+  {
+    "_id": "bk102",
+    "author": "Ralls, Kim",
+    "description": "A former architect battles corporate zombies,\n      an evil sorceress, and her own childhood to become queen\n      of the world.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2000-12-16",
+    "title": "Midnight Rain"
+  },
+  {
+    "_id": "bk103",
+    "author": "Corets, Eva",
+    "description": "After the collapse of a nanotechnology\n      society in England, the young survivors lay the\n      foundation for a new society.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2000-11-17",
+    "title": "Maeve Ascendant"
+  },
+  {
+    "_id": "bk104",
+    "author": "Corets, Eva",
+    "description": "In post-apocalypse England, the mysterious\n      agent known only as Oberon helps to create a new life\n      for the inhabitants of London. Sequel to Maeve\n      Ascendant.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2001-03-10",
+    "title": "Oberon's Legacy"
+  },
+  {
+    "_id": "bk105",
+    "author": "Corets, Eva",
+    "description": "The two daughters of Maeve, half-sisters,\n      battle one another for control of England. Sequel to\n      Oberon's Legacy.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2001-09-10",
+    "title": "The Sundered Grail"
+  },
+  {
+    "_id": "bk106",
+    "author": "Randall, Cynthia",
+    "description": "When Carla meets Paul at an ornithology\n      conference, tempers fly as feathers get ruffled.",
+    "genre": "Romance",
+    "price": 4.95,
+    "publish_date": "2000-09-02",
+    "title": "Lover Birds"
+  },
+  {
+    "_id": "bk107",
+    "author": "Thurman, Paula",
+    "description": "A deep sea diver finds true love twenty\n      thousand leagues beneath the sea.",
+    "genre": "Romance",
+    "price": 4.95,
+    "publish_date": "2000-11-02",
+    "title": "Splish Splash"
+  },
+  {
+    "_id": "bk108",
+    "author": "Knorr, Stefan",
+    "description": "An anthology of horror stories about roaches,\n      centipedes, scorpions  and other insects.",
+    "genre": "Horror",
+    "price": 4.95,
+    "publish_date": "2000-12-06",
+    "title": "Creepy Crawlies"
+  },
+  {
+    "_id": "bk109",
+    "author": "Kress, Peter",
+    "description": "After an inadvertant trip through a Heisenberg\n      Uncertainty Device, James Salway discovers the problems\n      of being quantum.",
+    "genre": "Science Fiction",
+    "price": 6.95,
+    "publish_date": "2000-11-02",
+    "title": "Paradox Lost"
+  },
+  {
+    "_id": "bk110",
+    "author": "O'Brien, Tim",
+    "description": "Microsoft's .NET initiative is explored in\n      detail in this deep programmer's reference.",
+    "genre": "Computer",
+    "price": 36.95,
+    "publish_date": "2000-12-09",
+    "title": "Microsoft .NET: The Programming Bible"
+  },
+  {
+    "_id": "bk111",
+    "author": "O'Brien, Tim",
+    "description": "The Microsoft MSXML3 parser is covered in\n      detail, with attention to XML DOM interfaces, XSLT processing,\n      SAX and more.",
+    "genre": "Computer",
+    "price": 36.95,
+    "publish_date": "2000-12-01",
+    "title": "MSXML3: A Comprehensive Guide"
+  },
+  {
+    "_id": "bk112",
+    "author": "Galos, Mike",
+    "description": "Microsoft Visual Studio 7 is explored in depth,\n      looking at how Visual Basic, Visual C++, C#, and ASP+ are\n      integrated into a comprehensive development\n      environment.",
+    "genre": "Computer",
+    "price": 49.95,
+    "publish_date": "2001-04-16",
+    "title": "Visual Studio 7: A Comprehensive Guide"
+  }
+]

--- a/tests/library/pipeline/fixed_width_pipeline/v1/output/my_view.json
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/output/my_view.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "002",
+    "some_date": "01302017",
+    "some_string": "me",
+    "some_integer": 5678
+  }
+]

--- a/tests/library/pipeline/fixed_width_pipeline/v1/output/my_xml_view.json
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/output/my_xml_view.json
@@ -1,0 +1,110 @@
+[
+  {
+    "_id": "bk101",
+    "author": "Gambardella, Matthew",
+    "description": "\n\n\n         An in-depth look at creating applications\n         with XML.This manual describes Oracle XML DB, and how you can use it to store, generate, manipulate, manage,\n         and query XML data in the database.\n\n\n         After introducing you to the heart of Oracle XML DB, namely the XMLType framework and Oracle XML DB repository,\n         the manual provides a brief introduction to design criteria to consider when planning your Oracle XML DB\n         application. It provides examples of how and where you can use Oracle XML DB.\n\n\n         The manual then describes ways you can store and retrieve XML data using Oracle XML DB, APIs for manipulating\n         XMLType data, and ways you can view, generate, transform, and search on existing XML data. The remainder of\n         the manual discusses how to use Oracle XML DB repository, including versioning and security,\n         how to access and manipulate repository resources using protocols, SQL, PL/SQL, or Java, and how to manage\n         your Oracle XML DB application using Oracle Enterprise Manager. It also introduces you to XML messaging and\n         Oracle Streams Advanced Queuing XMLType support.\n      ",
+    "genre": "Computer",
+    "price": 44.95,
+    "publish_date": "2000-10-01",
+    "title": "XML Developer's Guide"
+  },
+  {
+    "_id": "bk102",
+    "author": "Ralls, Kim",
+    "description": "A former architect battles corporate zombies,\n      an evil sorceress, and her own childhood to become queen\n      of the world.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2000-12-16",
+    "title": "Midnight Rain"
+  },
+  {
+    "_id": "bk103",
+    "author": "Corets, Eva",
+    "description": "After the collapse of a nanotechnology\n      society in England, the young survivors lay the\n      foundation for a new society.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2000-11-17",
+    "title": "Maeve Ascendant"
+  },
+  {
+    "_id": "bk104",
+    "author": "Corets, Eva",
+    "description": "In post-apocalypse England, the mysterious\n      agent known only as Oberon helps to create a new life\n      for the inhabitants of London. Sequel to Maeve\n      Ascendant.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2001-03-10",
+    "title": "Oberon's Legacy"
+  },
+  {
+    "_id": "bk105",
+    "author": "Corets, Eva",
+    "description": "The two daughters of Maeve, half-sisters,\n      battle one another for control of England. Sequel to\n      Oberon's Legacy.",
+    "genre": "Fantasy",
+    "price": 5.95,
+    "publish_date": "2001-09-10",
+    "title": "The Sundered Grail"
+  },
+  {
+    "_id": "bk106",
+    "author": "Randall, Cynthia",
+    "description": "When Carla meets Paul at an ornithology\n      conference, tempers fly as feathers get ruffled.",
+    "genre": "Romance",
+    "price": 4.95,
+    "publish_date": "2000-09-02",
+    "title": "Lover Birds"
+  },
+  {
+    "_id": "bk107",
+    "author": "Thurman, Paula",
+    "description": "A deep sea diver finds true love twenty\n      thousand leagues beneath the sea.",
+    "genre": "Romance",
+    "price": 4.95,
+    "publish_date": "2000-11-02",
+    "title": "Splish Splash"
+  },
+  {
+    "_id": "bk108",
+    "author": "Knorr, Stefan",
+    "description": "An anthology of horror stories about roaches,\n      centipedes, scorpions  and other insects.",
+    "genre": "Horror",
+    "price": 4.95,
+    "publish_date": "2000-12-06",
+    "title": "Creepy Crawlies"
+  },
+  {
+    "_id": "bk109",
+    "author": "Kress, Peter",
+    "description": "After an inadvertant trip through a Heisenberg\n      Uncertainty Device, James Salway discovers the problems\n      of being quantum.",
+    "genre": "Science Fiction",
+    "price": 6.95,
+    "publish_date": "2000-11-02",
+    "title": "Paradox Lost"
+  },
+  {
+    "_id": "bk110",
+    "author": "O'Brien, Tim",
+    "description": "Microsoft's .NET initiative is explored in\n      detail in this deep programmer's reference.",
+    "genre": "Computer",
+    "price": 36.95,
+    "publish_date": "2000-12-09",
+    "title": "Microsoft .NET: The Programming Bible"
+  },
+  {
+    "_id": "bk111",
+    "author": "O'Brien, Tim",
+    "description": "The Microsoft MSXML3 parser is covered in\n      detail, with attention to XML DOM interfaces, XSLT processing,\n      SAX and more.",
+    "genre": "Computer",
+    "price": 36.95,
+    "publish_date": "2000-12-01",
+    "title": "MSXML3: A Comprehensive Guide"
+  },
+  {
+    "_id": "bk112",
+    "author": "Galos, Mike",
+    "description": "Microsoft Visual Studio 7 is explored in depth,\n      looking at how Visual Basic, Visual C++, C#, and ASP+ are\n      integrated into a comprehensive development\n      environment.",
+    "genre": "Computer",
+    "price": 49.95,
+    "publish_date": "2001-04-16",
+    "title": "Visual Studio 7: A Comprehensive Guide"
+  }
+]

--- a/tests/library/pipeline/fixed_width_pipeline/v1/output_schema/books.json
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/output_schema/books.json
@@ -1,0 +1,48 @@
+{
+    "type": "struct",
+    "fields": [
+        {
+            "name": "_id",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "author",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "description",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "genre",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "price",
+            "type": "double",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "publish_date",
+            "type": "date",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "title",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        }
+    ],
+    "$schema": "https://raw.githubusercontent.com/imranq2/SparkPipelineFramework.Testing/main/spark_json_schema.json "
+}

--- a/tests/library/pipeline/fixed_width_pipeline/v1/output_schema/my_view.json
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/output_schema/my_view.json
@@ -1,0 +1,30 @@
+{
+    "type": "struct",
+    "fields": [
+        {
+            "name": "id",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "some_date",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "some_string",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "some_integer",
+            "type": "integer",
+            "nullable": true,
+            "metadata": {}
+        }
+    ],
+    "$schema": "https://raw.githubusercontent.com/imranq2/SparkPipelineFramework.Testing/main/spark_json_schema.json "
+}

--- a/tests/library/pipeline/fixed_width_pipeline/v1/output_schema/my_xml_view.json
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/output_schema/my_xml_view.json
@@ -1,0 +1,48 @@
+{
+    "type": "struct",
+    "fields": [
+        {
+            "name": "_id",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "author",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "description",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "genre",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "price",
+            "type": "double",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "publish_date",
+            "type": "date",
+            "nullable": true,
+            "metadata": {}
+        },
+        {
+            "name": "title",
+            "type": "string",
+            "nullable": true,
+            "metadata": {}
+        }
+    ],
+    "$schema": "https://raw.githubusercontent.com/imranq2/SparkPipelineFramework.Testing/main/spark_json_schema.json "
+}

--- a/tests/library/pipeline/fixed_width_pipeline/v1/test_fixed_width_pipeline.py
+++ b/tests/library/pipeline/fixed_width_pipeline/v1/test_fixed_width_pipeline.py
@@ -13,7 +13,7 @@ from spark_pipeline_framework_testing.test_runner_v2 import (
     SparkPipelineFrameworkTestRunnerV2,
 )
 
-from spark_pipeline_framework_testing.test_classes import input_types
+from spark_pipeline_framework_testing.test_classes import input_types, validator_types
 
 
 def test_fixed_width_pipeline(
@@ -59,7 +59,9 @@ def test_fixed_width_pipeline(
         spark_session=spark_session,
         test_path=data_dir,
         test_name=test_name,
-        test_validators=[],
+        test_validators=[validator_types.OutputFileValidator(
+            output_folder="output", ignore_views_for_output=["test"]
+        )],
         logger=logger,
         test_inputs=[test_input],
         temp_folder="output/temp",


### PR DESCRIPTION
- attempting to fix OutputFileValidator so that whatever views are specified via ignore_views_for_output are not used to generate the output files and schema and are not used for comparison