### PR TITLE
IOP-3522 - Remove the jar files present in create_spark_session.py which are not required

### DIFF
--- a/create_spark_session.py
+++ b/create_spark_session.py
@@ -75,15 +75,15 @@ def create_spark_session(request: Any) -> SparkSession:
         os.environ["SPARK_HOME"] = "/usr/local/opt/spark"
     clean_spark_dir()
     master = "local[2]"
-    jars = [
-        "mysql:mysql-connector-java:8.0.24",
-        "org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.0",
-        "io.delta:delta-core_2.12:2.1.0",
-        "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.2",
-        "org.apache.spark:spark-hadoop-cloud_2.12:3.3.1",
-        "com.amazonaws:aws-java-sdk-bundle:1.12.339",
-        "com.databricks:spark-xml_2.12:0.15.0",
-    ]
+    # These jar files are already contained in the imranq2/helix.spark image
+    # jars = [
+    #     "mysql:mysql-connector-java:8.0.24",
+    #     "org.apache.spark:spark-sql-kafka-0-10_2.12:3.3.0",
+    #     "com.johnsnowlabs.nlp:spark-nlp_2.12:4.2.2",
+    #     "org.apache.spark:spark-hadoop-cloud_2.12:3.3.1",
+    #     "com.amazonaws:aws-java-sdk-bundle:1.12.339",
+    #     "com.databricks:spark-xml_2.12:0.15.0",
+    # ]
     session = (
         SparkSession.builder.appName("pytest-pyspark-local-testing")
         .master(master)
@@ -96,7 +96,7 @@ def create_spark_session(request: Any) -> SparkSession:
             "spark.sql.catalog.spark_catalog",
             "org.apache.spark.sql.delta.catalog.DeltaCatalog",
         )
-        .config("spark.jars.packages", ",".join(jars))
+        # .config("spark.jars.packages", ",".join(jars))
         .enableHiveSupport()
         .getOrCreate()
     )


### PR DESCRIPTION
…

The jar files mentioned in the create_session.py are not required as its already present in the base image: imranq2/helix.spark